### PR TITLE
Pin http dependency to ~4.4.0

### DIFF
--- a/fulfil.gemspec
+++ b/fulfil.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.3.0'
 
-  spec.add_dependency 'http'
+  spec.add_dependency 'http', '~> 4.4.1'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'minitest', '~> 5.0'


### PR DESCRIPTION
5.0 introduced a frozen string error.