### PR TITLE
Streamline the usage of environment variables.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+FULFIL_API_TOKEN=fulfil-api-token
+FULFIL_CLIENT_ID=fulfil-client-id
+FULFIL_CLIENT_SECRET=fulfil-client-secret
+FULFIL_OAUTH_TOKEN=fulfil-oauth-token
+FULFIL_SUBDOMAIN=fulfil-subdomain

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /spec/reports/
 /tmp/
 Gemfile.lock
+.env

--- a/README.md
+++ b/README.md
@@ -14,23 +14,27 @@ gem 'fulfil-io', require: 'fulfil'
 
 And then execute:
 
-    $ bundle install
+```shell
+  $ bundle install
+```
 
 Or install it yourself as:
 
-    $ gem install fulfil-io
+```shell
+  $ gem install fulfil-io
+```
 
 ## Usage
 
 Environment variables:
 
-- FULFIL_SUBDOMAIN - required to be set.
-- FULFIL_TOKEN - required for oauth bearer authentication
-- FULFIL_API_KEY - required for authentication via the X-API-KEY request header
+- **FULFIL_SUBDOMAIN:** - always required to use the gem.
+- **FULFIL_OAUTH_TOKEN:** required for oauth bearer authentication
+- **FULFIL_API_KEY:** required for authentication via the `X-API-KEY` request header
 
-**Note:** When FULFIL_TOKEN is present, the FULFIL_API_KEY will be ignored. So,
+> **Note:** When `FULFIL_OAUTH_TOKEN` is present, the `FULFIL_API_KEY` will be ignored. So,
 if oauth doesn't work, returning an Unauthorized error, to use the
-FULFIL_API_KEY, the FULFIL_TOKEN shouldn't be specified.
+`FULFIL_API_KEY`, the `FULFIL_OAUTH_TOKEN` shouldn't be specified.
 
 ```ruby
 require 'fulfil' # this is necessary only in case of running without bundler
@@ -145,7 +149,7 @@ For non-client tests, create the test class or case.
 
 For client tests, you'll need to add a couple steps. If running against a real
 backend, you'll need to provide a couple of environment variables:
-`FULFIL_SUBDOMAIN` and `FULFIL_TOKEN`. Additionally, pass `debug: true` to the
+`FULFIL_SUBDOMAIN` and `FULFIL_OAUTH_TOKEN`. Additionally, pass `debug: true` to the
 client instance in the test. This will output the response body. Webmock will
 probably complain that real requests aren't allowed at this point, offering you
 the stub. We don't need most of that.

--- a/bin/authenticate
+++ b/bin/authenticate
@@ -1,17 +1,16 @@
 #!/usr/bin/env ruby
-
 # frozen_string_literal: true
 
-require 'bundler'
-Bundler.setup(:default, :development)
+require 'dotenv/load'
+require 'bundler/setup'
 
-require 'oauth2'
 require 'fulfil'
+require 'oauth2'
 
 def get_token
-  client_id = ENV.fetch('CLIENT_ID')
-  client_secret = ENV.fetch('CLIENT_SECRET')
-  subdomain = ENV.fetch('SUBDOMAIN')
+  client_id = ENV.fetch('FULFIL_CLIENT_ID')
+  client_secret = ENV.fetch('FULFIL_CLIENT_SECRET')
+  subdomain = ENV.fetch('FULFIL_SUBDOMAIN')
 
   base_url = "https://#{subdomain}.fulfil.io" # "oauth/authorize"
 
@@ -47,7 +46,7 @@ end
 
 def fulfil
   @fulfil ||= Fulfil::Client.new(
-    subdomain: ENV.fetch('SUBDOMAIN'), token: ENV.fetch('TOKEN')
+    subdomain: ENV.fetch('FULFIL_SUBDOMAIN'), token: ENV.fetch('FULFIL_OAUTH_TOKEN')
   )
 end
 

--- a/bin/console
+++ b/bin/console
@@ -1,11 +1,14 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
+require 'dotenv/load'
 require 'bundler/setup'
+
 require 'fulfil'
 
 def fulfil
   @fulfil ||= Fulfil::Client.new(
-    subdomain: ENV.fetch('SUBDOMAIN'), token: ENV.fetch('TOKEN')
+    subdomain: ENV.fetch('FULFIL_SUBDOMAIN'), token: ENV.fetch('FULFIL_OAUTH_TOKEN')
   )
 end
 

--- a/bin/console
+++ b/bin/console
@@ -7,8 +7,15 @@ require 'bundler/setup'
 require 'fulfil'
 
 def fulfil
+  oauth_token = ENV['FULFIL_OAUTH_TOKEN'] || ENV['FULFIL_TOKEN']
+
+  if ENV['FULFIL_TOKEN']
+    puts "You're using an deprecated environment variable. Please update your " \
+          'FULFIL_TOKEN to FULFIL_OAUTH_TOKEN.'
+  end
+
   @fulfil ||= Fulfil::Client.new(
-    subdomain: ENV.fetch('FULFIL_SUBDOMAIN'), token: ENV.fetch('FULFIL_OAUTH_TOKEN')
+    subdomain: ENV.fetch('FULFIL_SUBDOMAIN'), token: oauth_token
   )
 end
 

--- a/bin/setup
+++ b/bin/setup
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 IFS=$'\n\t'
-set -vx
 
-bundle install
+echo "[Fulfil] Installing all dependencies."
+bundle install --quiet
 
-# Do any other automated setup that you need to do here
+# Setup the environment variables for local development.
+echo "[Fulfil] Setting up environment variables."
+cp .env.example .env

--- a/fulfil.gemspec
+++ b/fulfil.gemspec
@@ -30,4 +30,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'oauth2', '~> 1.4'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'webmock'
+  spec.add_development_dependency 'dotenv', '~> 2.7', '>= 2.7.6'
 end

--- a/lib/fulfil/client.rb
+++ b/lib/fulfil/client.rb
@@ -7,7 +7,6 @@ require 'fulfil/response_parser'
 module Fulfil
   SUBDOMAIN = ENV['FULFIL_SUBDOMAIN']
   API_KEY = ENV['FULFIL_API_KEY']
-  OAUTH_TOKEN = ENV['FULFIL_TOKEN']
 
   class Client
     class InvalidClientError < StandardError
@@ -24,7 +23,7 @@ module Fulfil
 
     class ResponseError < StandardError; end
 
-    def initialize(subdomain: SUBDOMAIN, token: OAUTH_TOKEN, headers: { 'X-API-KEY' => API_KEY }, debug: false)
+    def initialize(subdomain: SUBDOMAIN, token: oauth_token, headers: { 'X-API-KEY' => API_KEY }, debug: false)
       @subdomain = subdomain
       @token = token
       @debug = debug
@@ -111,6 +110,15 @@ module Fulfil
     end
 
     private
+
+    def oauth_token
+      if ENV['FULFIL_TOKEN']
+        puts "You're using an deprecated environment variable. Please update your " \
+              'FULFIL_TOKEN to FULFIL_OAUTH_TOKEN.'
+      end
+
+      ENV['FULFIL_OAUTH_TOKEN'] || ENV['FULFIL_TOKEN']
+    end
 
     def parse(result: nil, results: [])
       if result

--- a/test/support/fulfil_helper.rb
+++ b/test/support/fulfil_helper.rb
@@ -61,7 +61,7 @@ module FulfilHelper
 
   def valid_request_headers_with_auth_token
     DEFAULT_HEADERS.merge(
-      'Authorization' => "Bearer #{ENV.fetch('FULFIL_API_TOKEN')}"
+      'Authorization' => "Bearer #{ENV.fetch('FULFIL_OAUTH_TOKEN')}"
     )
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'dotenv/load'
+
 $LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 require 'fulfil'
 


### PR DESCRIPTION
Currently, we're using different sorts of environment variables, and running tests locally is hard(er) because the environment variables aren't directly loaded (not the best DX). 

This PR does a couple of things:
- Adds `dotenv` to load the environment variables to improve the DX.
- Improves the `bin/setup` script to copy the `.env.example` to `.env` file.
- Deprecate the `FULFIL_TOKEN` for the more descriptive `FULFIL_OAUTH_TOKEN`.

The feedback I'm looking for: should we deprecate the `FULFIL_TOKEN`? I feel it's less descriptive, however, we're also using it already for quite some projects. We might want to do this in a different PR (if at all)?