### PR TITLE
Remove extremely precise User-Agent from mocks.

### DIFF
--- a/test/support/fulfil_helper.rb
+++ b/test/support/fulfil_helper.rb
@@ -5,8 +5,7 @@ require 'webmock/minitest'
 module FulfilHelper
   DEFAULT_HEADERS = {
     'Connection' => 'Keep-Alive',
-    'Host' => "#{ENV.fetch('FULFIL_SUBDOMAIN')}.fulfil.io",
-    'User-Agent' => 'http.rb/4.4.1'
+    'Host' => "#{ENV.fetch('FULFIL_SUBDOMAIN')}.fulfil.io"
   }.freeze
 
   def stub_fulfil_get(path, fixture, status_code = 200)


### PR DESCRIPTION
Using the `User-Agent` in the mocks adds very little value and it will break depending on the HTTP gem version we're using. This fixes the problem by removing the `User-Agent` from the stubs.