### PR TITLE
Remove persistent connection and client caching

### DIFF
--- a/lib/fulfil/client.rb
+++ b/lib/fulfil/client.rb
@@ -169,7 +169,7 @@ module Fulfil
     def client
       return @client if defined?(@client)
 
-      @client = HTTP.persistent(base_url).use(logging: @debug ? { logger: Logger.new(STDOUT) } : {})
+      @client = HTTP.use(logging: @debug ? { logger: Logger.new(STDOUT) } : {})
       @client = @client.auth("Bearer #{@token}") if @token
       @client = @client.headers(@headers)
       @client

--- a/lib/fulfil/client.rb
+++ b/lib/fulfil/client.rb
@@ -167,12 +167,10 @@ module Fulfil
     end
 
     def client
-      return @client if defined?(@client)
-
-      @client = HTTP.use(logging: @debug ? { logger: Logger.new(STDOUT) } : {})
-      @client = @client.auth("Bearer #{@token}") if @token
-      @client = @client.headers(@headers)
-      @client
+      client = HTTP.use(logging: @debug ? { logger: Logger.new(STDOUT) } : {})
+      client = client.auth("Bearer #{@token}") if @token
+      client = client.headers(@headers)
+      client
     end
   end
 end

--- a/test/support/fulfil_helper.rb
+++ b/test/support/fulfil_helper.rb
@@ -4,7 +4,6 @@ require 'webmock/minitest'
 
 module FulfilHelper
   DEFAULT_HEADERS = {
-    'Connection' => 'Keep-Alive',
     'Host' => "#{ENV.fetch('FULFIL_SUBDOMAIN')}.fulfil.io"
   }.freeze
 


### PR DESCRIPTION
This PR deprecates the persistent HTTP connection and removes the caching of the HTTP client used by Fulfil. When using the `fulfil` gem in background jobs, the caching and the persistent HTTP connection might cause unexpected connection closures.

Setting up new HTTP clients for every request is cheap and thus there is no need for caching it. 