### PR TITLE
Add rate limit detection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-FULFIL_API_TOKEN=fulfil-api-token
+FULFIL_API_KEY=fulfil-api-key
 FULFIL_CLIENT_ID=fulfil-client-id
 FULFIL_CLIENT_SECRET=fulfil-client-secret
 FULFIL_OAUTH_TOKEN=fulfil-oauth-token

--- a/README.md
+++ b/README.md
@@ -127,6 +127,26 @@ report = Fulfil::Report.new(client: fulfil, report_name: 'account.tax.summary.ir
 report.execute(start_date: Date.new(2020, 12, 1), end_date: Date.new(2020, 12, 31))
 ```
 
+## Rate limits
+
+Fulfil's API applies rate limits to the API requests that it receives. Every request is subject to throttling under the general limits. In addition, there are resource-based rate limits and throttles.
+
+This gem exposes an API for checking your current rate limits (note: the gem only knows about the rate limit after a request to Fulfil's API has been made).
+
+Whenever you reached the rate limit, the `Fulfil::RateLimitExceeded` exception is being raised. You can use the information on the `Fulfil.rate_limit` to find out what to do next.
+
+```ruby
+$ Fulfil.rate_limit.requests_left? # or use Fulfil.rate_limit.exceeded?
+=> true
+
+# The maximum number of requests you're permitted to make per second.
+$ Fulfil.rate_limit.limit
+=> 9
+
+# The time at which the current rate limit window resets in UTC epoch seconds.
+$ Fulfil.rate_limit.resets_at
+=> #<DateTime: 2022-01-21T16:36:01-04:00 />
+```
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run

--- a/lib/fulfil.rb
+++ b/lib/fulfil.rb
@@ -7,6 +7,10 @@ require 'fulfil/model'
 require 'fulfil/interactive_report'
 require 'fulfil/response_handler'
 require 'fulfil/response_parser'
+require 'fulfil/rate_limit'
 
 module Fulfil
+  def self.rate_limit
+    @rate_limit ||= RateLimit.new
+  end
 end

--- a/lib/fulfil/error.rb
+++ b/lib/fulfil/error.rb
@@ -3,6 +3,8 @@
 module Fulfil
   class Error < StandardError; end
 
+  class RateLimitExceeded < Error; end
+
   # The `Fulfil::HttpError` is raised whenever an API request returns a 400+ HTTP status code.
   # See `Fulfil::ResponseHandler` for more information.
   class HttpError < Error

--- a/lib/fulfil/rate_limit.rb
+++ b/lib/fulfil/rate_limit.rb
@@ -27,6 +27,7 @@ module Fulfil
     def requests_left?
       requests_left.positive?
     end
+    alias exceeded? requests_left?
 
     private
 

--- a/lib/fulfil/rate_limit.rb
+++ b/lib/fulfil/rate_limit.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module Fulfil
+  # The `Fulfil::RateLimit` allows clients to keep track of their API usage.
+  class RateLimit
+    attr_reader :limit, :requests_left, :resets_at
+
+    def initialize
+      @limit = 0
+      @requests_left = 0
+      @resets_at = nil
+    end
+
+    # Analyses the rate limit based on the response headers from Fulfil.
+    # @param headers [HTTP::Headers] The HTTP response headers from Fulfil.
+    # @return [Fulfil::RateLimit]
+    def analyse!(headers)
+      self.limit = headers['X-RateLimit-Limit']
+      self.requests_left = headers['X-RateLimit-Remaining']
+      self.resets_at = headers['X-RateLimit-Reset']
+
+      raise Fulfil::RateLimitExceeded unless requests_left?
+    end
+
+    # Returns whether there are any requests left in the current rate limit window.
+    # @return [Boolean]
+    def requests_left?
+      requests_left.positive?
+    end
+
+    private
+
+    # Sets the maximum number of requests you're permitted to make per second.
+    # @param value [String] The maximum number of requests per second.
+    # @return [Integer] The maximum number of requests per second.
+    def limit=(value)
+      @limit = value.to_i
+    end
+
+    # Sets number of requests remaining in the current rate limit window.
+    # @param value [String] The remaining number of requests for the current time window.
+    # @return [Integer] The remaining number of requests for the current time window.
+    def requests_left=(value)
+      @requests_left = value.to_i
+    end
+
+    # Sets the time at which the current rate limit window resets in UTC epoch seconds.
+    # @param value [Integer|nil] Time as an integer in UTC epoch seconds.
+    # @return [DataTime|nil] The moment the rate limit resets.
+    def resets_at=(value)
+      @resets_at =
+        if value.nil?
+          nil
+        else
+          Time.at(value.to_i).utc.to_datetime
+        end
+    end
+  end
+end

--- a/lib/fulfil/response_handler.rb
+++ b/lib/fulfil/response_handler.rb
@@ -31,6 +31,17 @@ module Fulfil
     end
 
     def verify!
+      verify_rate_limits!
+      verify_http_status_code!
+    end
+
+    private
+
+    def verify_rate_limits!
+      Fulfil.rate_limit.analyse!(@response.headers)
+    end
+
+    def verify_http_status_code!
       return true unless @status_code >= 400
 
       raise HTTP_ERROR_CODES.fetch(@status_code, Fulfil::HttpError).new(
@@ -42,8 +53,6 @@ module Fulfil
         }
       )
     end
-
-    private
 
     def response_body
       @response_body ||= @response.parse

--- a/test/fulfil/rate_limit_test.rb
+++ b/test/fulfil/rate_limit_test.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+
+class RateLimitTest < Minitest::Test
+  def setup
+    @current_time = Time.now
+
+    @response_headers = {
+      'X-RateLimit-Limit' => '10',
+      'X-RateLimit-Remaining' => '9',
+      'X-RateLimit-Reset' => @current_time.utc.to_i
+    }
+  end
+
+  def test_default_values
+    rate_limit = Fulfil::RateLimit.new
+
+    assert_equal 0, rate_limit.limit
+    assert_equal 0, rate_limit.requests_left
+    assert_nil rate_limit.resets_at
+  end
+
+  def test_rate_limit_assignments
+    rate_limit = Fulfil::RateLimit.new
+    rate_limit.analyse!(@response_headers)
+
+    assert_equal 10, rate_limit.limit
+    assert_equal 9, rate_limit.requests_left
+    assert_in_delta @current_time.to_datetime, rate_limit.resets_at
+  end
+
+  def test_rate_limit_requests_left
+    rate_limit = Fulfil::RateLimit.new
+    refute rate_limit.requests_left?
+
+    rate_limit.analyse!(@response_headers)
+    assert rate_limit.requests_left?
+  end
+end

--- a/test/fulfil/response_handler_test.rb
+++ b/test/fulfil/response_handler_test.rb
@@ -25,7 +25,12 @@ class ResponseHandlerTest < Minitest::Test
     end
 
     def headers
-      { 'Response-Type': 'application/json' }
+      {
+        'Response-Type' => 'application/json',
+        'X-RateLimit-Limit' => 10,
+        'X-RateLimit-Remaining' => 9,
+        'X-RateLimit-Reset' => Time.now.utc.to_i
+      }
     end
 
     def status

--- a/test/support/fulfil_helper.rb
+++ b/test/support/fulfil_helper.rb
@@ -9,13 +9,12 @@ module FulfilHelper
 
   def stub_fulfil_get(path, fixture, status_code = 200)
     stub_request(:get, "https://#{ENV.fetch('FULFIL_SUBDOMAIN')}.fulfil.io/api/v2/model/#{path}")
-      .with(headers: valid_request_headers)
       .to_return(status: status_code, body: load_fixture(fixture), headers: valid_response_headers)
   end
 
   def stub_fulfil_put(path, fixture, body, status_code = 200)
     stub_request(:put, "https://#{ENV.fetch('FULFIL_SUBDOMAIN')}.fulfil.io/api/v2/model/#{path}")
-      .with(headers: valid_request_headers, body: body)
+      .with(body: body)
       .to_return(status: status_code, body: load_fixture(fixture), headers: valid_response_headers)
   end
 
@@ -52,8 +51,11 @@ module FulfilHelper
 
   def valid_response_headers
     {
+      'Accept': 'application/json',
       'Content-Type': 'application/json',
-      'Accept': 'application/json'
+      'X-RateLimit-Limit': 10,
+      'X-RateLimit-Remaining': 9,
+      'X-RateLimit-Reset': Time.now.utc.to_i
     }
   end
 


### PR DESCRIPTION
Fixes #23 

This adds rate limit detection to the Fulfil gem. Allowing clients to watch for the `Fulfil::RateLimitExceeded` exception and handle accordingly. 

Also exposes helpful information about the current quota:
- `Fulfil.rate_limit.requests_left?` (aliased by `Fulfil.rate_limit.exceeded?`)
- `Fulfil.rate_limit.limit` exposes the maximum number of requests you're permitted to make per second.
- `Fulfil.rate_limit.resets_at` exposes the time at which the current rate limit window resets in UTC epoch seconds.