### PR TITLE
Fixes a typo in the examples of the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ sale_model = Fulfil::Model.new(
 )
 
 sales = sale_model.search(
-  domain: [['id', '=', [10]]],
+  domain: [['id', '=', 10]],
   fields: ['id', 'rec_name', 'lines']
 )
 


### PR DESCRIPTION
The readme states that you can do a search query with `domain: [['id', '=', [10]]]`. However, this is only possible if you use `in` instead of `=`. This updates the documentation to make sure the first example is actually a working example :)! 