### PR TITLE
Fix requiring gemfiles manually

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A Ruby library for the [Fulfil.io](https://fulfil.io) API.
 Add this line to your application's Gemfile:
 
 ```ruby
-  gem 'fulfil-io', require: 'fulfil'
+  gem 'fulfil-io'
 ```
 
 And then execute:
@@ -37,8 +37,6 @@ if oauth doesn't work, returning an Unauthorized error, to use the
 `FULFIL_API_KEY`, the `FULFIL_OAUTH_TOKEN` shouldn't be specified.
 
 ```ruby
-require 'fulfil' # this is necessary only in case of running without bundler
-
 fulfil = Fulfil::Client.new # or, to enable request debugging, Fulfil::Client.new(debug: true)
 
 sale_model = Fulfil::Model.new(

--- a/fulfil.gemspec
+++ b/fulfil.gemspec
@@ -14,7 +14,10 @@ Gem::Specification.new do |spec|
 
   # Specify which files should be added to the gem when it is released.
   # To include hidden files from the lib/ folder you need to use the File::FNM_DOTMATCH flag
-  spec.files         = Dir.glob(%w[lib/**/* Rakefile], File::FNM_DOTMATCH)
+  spec.files = Dir.chdir(File.expand_path(__dir__)) do
+    Dir['lib/**/*', 'LICENSE', 'Rakefile', 'README.md']
+  end
+
   spec.bindir        = 'bin'
   spec.require_paths = 'lib'
   spec.extra_rdoc_files = Dir['README.md', 'CHANGELOG.md', 'LICENSE.txt']

--- a/lib/fulfil-io.rb
+++ b/lib/fulfil-io.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# By convention, Bundler will attempt to load the `fulfil/io.rb` or `fulfil-io.rb` file.
+# See https://guides.rubygems.org/name-your-gem/
+#
+# Due to this convention, the developer using this gem will need to manually
+# require fulfil in the Gemfile or anywhere else in their application.
+#
+# To make it a little bit more convenient, we've added the `fulfil-io.rb` file
+# that is loaded by default by Bundler and it's only job is to include all of
+# the other gem files.
+
+require 'fulfil'


### PR DESCRIPTION
I never liked that we needed to manually require the gem's file to make the gem actually work. So, I dug into why this happened (thanks @rjwhitmer for the nudge). 

The reason for this to happen is because Bundler automatically (attempts) to load the `lib/fulfil/io.rb` or the `lib/fulfil-io.rb`. Apparently, there are some nicely documented naming conventions for a gem: https://guides.rubygems.org/name-your-gem/

However, we're not actually following these naming conventions. The `fulfil` gem already existed, but wasn't maintained anymore, so we came up with `fulfil-io` as the gem's name. 

The downside of that choice was the way the auto-loading of a gem works. To fix the problem, we're actually adding a `lib/fulfil-io.rb` file that will require the `lib/fulfil.rb` file.

This will make it unnecessary to manually require the gem's files in the `Gemfile` of the host application.

```ruby
# Before
gem 'fulfil-io', '~> 0.6.0', require: 'fulfil'

# After
gem 'fulfil-io', '~> 0.6.0'
```