### PR TITLE
Remove _now from testing example

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ def test_find_one
   stub_fulfil_get('sale.sale/213112', 'sale_sale')
 
   client = Fulfil::Client.new
-  response = client.find_one(model: 'sale.sale', id: 213_112)
+  response = client.find(model: 'sale.sale', id: 213_112)
 
   assert_equal 213_112, response['id']
 end

--- a/README.md
+++ b/README.md
@@ -173,6 +173,18 @@ Fulfil.configure do |config|
 end
 ```
 
+## Retrieve multiple records
+
+To retrieve multiple records at once, one can pass the IDs into the find method directly.
+
+```ruby
+FulfilClient.find(
+  model: 'sale.sale',
+  ids: [1, 2, 3, 4],
+  fields: %w[id status]
+)
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run


### PR DESCRIPTION
The `find` method looks to see if there is an `id` or `ids` present and calls the proper `find_one` or `find_many` method.