### PR TITLE
Add SimpleCov for test coverage

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,6 +25,11 @@ jobs:
           cp .env.example .env
           bin/rake test
 
+      - name: Code Climate Coverage Action
+        uses: paambaati/codeclimate-action@v3.0.0
+        env:
+          CC_TEST_REPORTER_ID: b358904aab0061aa522f50917cb78091c0fab23ab0b72bbbee3f854c00d7435c
+
   linters:
     runs-on: ubuntu-latest
 

--- a/fulfil.gemspec
+++ b/fulfil.gemspec
@@ -37,5 +37,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '~> 1.36'
   spec.add_development_dependency 'rubocop-minitest', '~> 0.22.1'
   spec.add_development_dependency 'rubocop-performance', '~> 1.15'
+  spec.add_development_dependency 'simplecov', '~> 0.21.0'
   spec.add_development_dependency 'webmock'
 end

--- a/test/support/simplecov.rb
+++ b/test/support/simplecov.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 require 'simplecov'
+require 'simplecov_json_formatter'
 
 SimpleCov.start do
-  add_filter '/test/'
+  formatter SimpleCov::Formatter::JSONFormatter
 end

--- a/test/support/simplecov.rb
+++ b/test/support/simplecov.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'simplecov'
+
+SimpleCov.start do
+  add_filter '/test/'
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'support/simplecov' if ENV['CI']
+
 require 'dotenv/load'
 
 $LOAD_PATH.unshift File.expand_path('../lib', __dir__)


### PR DESCRIPTION
This adds SimpleCov to the CI process and outputs the results in JSON format. It adds a new step to the GitHub Actions that will send the results to [CodeClimate](https://codeclimate.com/github/knowndecimal/fulfil).