### PR TITLE
Improve rate-limit retry strategy (jitter, max attempts, reset-aware wait)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,13 @@ jobs:
       - name: Run all tests
         run: |
           cp .env.example .env
-          bin/rake test
+          timeout 10m bin/rake test || {
+            code=$?
+            if [ "$code" -eq 124 ]; then
+              echo "Test run timed out after 10 minutes"
+            fi
+            exit "$code"
+          }
 
       - name: Qlty Coverage Upload
         if: matrix.ruby-version == '3.4'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -31,3 +31,7 @@ Style/ClassAndModuleChildren:
 
 Gemspec/RequiredRubyVersion:
   Enabled: false
+
+Metrics/ClassLength:
+  Exclude:
+    - lib/fulfil/client.rb

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ Environment variables:
 
 - **FULFIL_SUBDOMAIN:** always required.
 - **FULFIL_OAUTH_TOKEN:** for OAuth bearer authentication.
-- **FULFIL_API_KEY:** for Personal Access Token authentication (sent as `X-API-KEY`).
+- **FULFIL_API_KEY:** for Personal Access Token authentication (sent as
+  `X-API-KEY`).
 
 Authentication behavior:
 
@@ -78,7 +79,8 @@ pp sales
 #   "rec_name"=>""}]
 ```
 
-To configure a client without using environment variables, pass credentials directly:
+To configure a client without using environment variables, pass credentials
+directly:
 
 With API key (preferred shortcut):
 
@@ -122,7 +124,7 @@ model.count(domain: [['shipping_batch.state', '=', 'open']])
 As of v0.3.0, we've added very basic support for creates and updates via
 `Fulfil::Client#post` and `Fulfil::Client#put`.
 
-*Create Example*
+_Create Example_
 
 ```ruby
 fulfil = Fulfil::Client.new
@@ -136,7 +138,7 @@ sale = {
 fulfil.post(model: sale_model, body: sale)
 ```
 
-*Update Example*
+_Update Example_
 
 ```ruby
 fulfil = Fulfil::Client.new
@@ -148,11 +150,11 @@ sale['channel'] = 4
 
 fulfil.put(model: sale_model, body: sale)
 ```
+
 ### Interactive Reports
 
-As of v0.4.6, interactive report support exists in a basic form.
-You're able to execute reports with basic params. Responses are
-transformed to JSON structures.
+As of v0.4.6, interactive report support exists in a basic form. You're able to
+execute reports with basic params. Responses are transformed to JSON structures.
 
 ```ruby
 fulfil = Fulfil::Client.new
@@ -164,11 +166,16 @@ report.execute(start_date: Date.new(2020, 12, 1), end_date: Date.new(2020, 12, 3
 
 ## Rate limits
 
-Fulfil's API applies rate limits to the API requests that it receives. Every request is subject to throttling under the general limits. In addition, there are resource-based rate limits and throttles.
+Fulfil's API applies rate limits to the API requests that it receives. Every
+request is subject to throttling under the general limits. In addition, there
+are resource-based rate limits and throttles.
 
-This gem exposes an API for checking your current rate limits (note: the gem only knows about the rate limit after a request to Fulfil's API has been made).
+This gem exposes an API for checking your current rate limits (note: the gem
+only knows about the rate limit after a request to Fulfil's API has been made).
 
-Whenever you reached the rate limit, the `Fulfil::RateLimitExceeded` exception is being raised. You can use the information on the `Fulfil.rate_limit` to find out what to do next.
+Whenever you reached the rate limit, the `Fulfil::RateLimitExceeded` exception
+is being raised. You can use the information on the `Fulfil.rate_limit` to find
+out what to do next.
 
 ```ruby
 $ Fulfil.rate_limit.requests_left?
@@ -185,7 +192,9 @@ $ Fulfil.rate_limit.resets_at
 
 ### Automatic retry API call after rate limit hit
 
-Automatic retries are supported whenever the rate limit is reached. However, it's not enabled by default. To enable it, set the `retry_on_rate_limit` to `true`. By default, the request will be retried in 1 second.
+Automatic retries are supported whenever the rate limit is reached. However,
+it's not enabled by default. To enable it, set the `retry_on_rate_limit` to
+`true`. By default, the request will be retried in 1 second.
 
 ```ruby
 # config/initializers/fulfil.rb
@@ -201,7 +210,8 @@ end
 
 ### Monitor rate limit hits
 
-Through the configurable `rate_limit_notification_handler` one can monitor the rate limit hits to the APM tool of choice.
+Through the configurable `rate_limit_notification_handler` one can monitor the
+rate limit hits to the APM tool of choice.
 
 ```ruby
 # config/initializers/fulfil.rb
@@ -215,7 +225,8 @@ end
 
 ## Retrieve multiple records
 
-To retrieve multiple records at once, one can pass the IDs into the find method directly.
+To retrieve multiple records at once, one can pass the IDs into the find method
+directly.
 
 ```ruby
 FulfilClient.find(
@@ -235,11 +246,13 @@ To install this gem onto your local machine, run `bundle exec rake install`.
 
 ### Release a new version
 
-We're following semver for the release process of this gem. Make sure to apply the correct semver version for a new release.
+We're following semver for the release process of this gem. Make sure to apply
+the correct semver version for a new release.
 
 To release a new version, run the `bin/release x.x.x`. That's it.
 
-> **NOTE:** You don't have to add a v to the version you want to release. The release script will handle that for you.
+> **NOTE:** You don't have to add a v to the version you want to release. The
+> release script will handle that for you.
 
 ### Testing
 
@@ -247,10 +260,10 @@ For non-client tests, create the test class or case.
 
 For client tests, you'll need to add a couple steps. If running against a real
 backend, you'll need to provide a couple of environment variables:
-`FULFIL_SUBDOMAIN` and `FULFIL_OAUTH_TOKEN`. Additionally, pass `debug: true` to the
-client instance in the test. This will output the response body. Webmock will
-probably complain that real requests aren't allowed at this point, offering you
-the stub. We don't need most of that.
+`FULFIL_SUBDOMAIN` and `FULFIL_OAUTH_TOKEN`. Additionally, pass `debug: true` to
+the client instance in the test. This will output the response body. Webmock
+will probably complain that real requests aren't allowed at this point, offering
+you the stub. We don't need most of that.
 
 We will need to capture the response body as JSON and store it in the
 `test/fixtures` directory. Formatted for readability, please. You'll also need
@@ -271,8 +284,8 @@ def test_find_one
 end
 ```
 
-`stub_fulfil_get` takes two arguments: the URL path (after `/api/v2/model/`)
-and the fixture file name to be returned.
+`stub_fulfil_get` takes two arguments: the URL path (after `/api/v2/model/`) and
+the fixture file name to be returned.
 
 ## Contributing
 
@@ -283,10 +296,11 @@ the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
 
 ## License
 
-The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).
+The gem is available as open source under the terms of the
+[MIT License](https://opensource.org/licenses/MIT).
 
 ## Code of Conduct
 
 Everyone interacting in the Fulfil project’s codebases, issue trackers, chat
-rooms and mailing lists is expected to follow the [code of
-conduct](https://github.com/[USERNAME]/fulfil/blob/master/CODE_OF_CONDUCT.md).
+rooms and mailing lists is expected to follow the
+[code of conduct](https://github.com/[USERNAME]/fulfil/blob/master/CODE_OF_CONDUCT.md).

--- a/README.md
+++ b/README.md
@@ -192,7 +192,10 @@ Automatic retries are supported whenever the rate limit is reached. However, it'
 
 Fulfil.configure do |config|
   config.retry_on_rate_limit = true # Defaults to false
-  config.retry_on_rate_limit_wait = 0.25 # Defaults to 1 (second)
+  config.retry_on_rate_limit_wait = 0.25 # Base wait fallback, defaults to 1 second
+  config.retry_on_rate_limit_max_attempts = 5 # Defaults to 3 retries
+  config.retry_on_rate_limit_jitter = 0.2 # +/- 20% random jitter, defaults to 0.2
+  config.retry_on_rate_limit_use_reset_at = true # Prefer X-RateLimit-Reset when present
 end
 ```
 

--- a/lib/fulfil.rb
+++ b/lib/fulfil.rb
@@ -12,6 +12,7 @@ require 'fulfil/response_parser'
 # Rate limiting
 require 'fulfil/rate_limit'
 require 'fulfil/rate_limit_headers'
+require 'fulfil/rate_limit_retry_wait'
 
 module Fulfil
   def self.rate_limit

--- a/lib/fulfil/client.rb
+++ b/lib/fulfil/client.rb
@@ -129,19 +129,9 @@ module Fulfil
     end
 
     def parse(result: nil, results: [])
-      if result
-        parse_single(result: result)
-      else
-        parse_multiple(results: results)
-      end
-    end
+      return Fulfil::ResponseParser.parse(item: result) if result
 
-    def parse_single(result:)
-      Fulfil::ResponseParser.parse(item: result)
-    end
-
-    def parse_multiple(results:)
-      results.map { |result| Fulfil::ResponseParser.parse(item: result) }
+      results.map { |item| Fulfil::ResponseParser.parse(item: item) }
     end
 
     def domain
@@ -184,27 +174,7 @@ module Fulfil
     end
 
     def rate_limit_retry_wait
-      wait = reset_aware_retry_wait || config.retry_on_rate_limit_wait.to_f
-      apply_jitter(wait)
-    end
-
-    def reset_aware_retry_wait
-      return unless config.retry_on_rate_limit_use_reset_at
-
-      reset_at = Fulfil.rate_limit.resets_at
-      return unless reset_at
-
-      reset_time = reset_at.respond_to?(:to_time) ? reset_at.to_time : Time.at(reset_at.to_i).utc
-      [reset_time - Time.now.utc, 0].max
-    end
-
-    def apply_jitter(wait)
-      jitter_ratio = config.retry_on_rate_limit_jitter.to_f
-      return wait if jitter_ratio <= 0
-
-      min = wait * (1 - jitter_ratio)
-      max = wait * (1 + jitter_ratio)
-      rand(min..max)
+      Fulfil::RateLimitRetryWait.call(config: config, reset_at: Fulfil.rate_limit.resets_at)
     end
 
     def client

--- a/lib/fulfil/client.rb
+++ b/lib/fulfil/client.rb
@@ -159,26 +159,28 @@ module Fulfil
     def request(endpoint:, verb: :get, **args)
       attempts = 0
 
-      response = client.request(verb, endpoint, args)
-      Fulfil::ResponseHandler.new(response).verify!
+      begin
+        response = client.request(verb, endpoint, args)
+        Fulfil::ResponseHandler.new(response).verify!
 
-      response.parse
-    rescue HTTP::ConnectionError => e
-      raise ConnectionError, "Can't connect to #{base_url}"
-    rescue HTTP::ResponseError => e
-      raise ResponseError, "Can't process response: #{e}"
-    rescue HTTP::Error => e
-      raise UnknownHTTPError, 'Unhandled HTTP error encountered'
-    # If configured, the client will wait whenever the `RateLimitExceeded` exception
-    # is raised. Check `Fulfil::Configuration` for more details.
-    rescue RateLimitExceeded => e
-      raise e unless config.retry_on_rate_limit?
+        response.parse
+      rescue HTTP::ConnectionError => e
+        raise ConnectionError, "Can't connect to #{base_url}"
+      rescue HTTP::ResponseError => e
+        raise ResponseError, "Can't process response: #{e}"
+      rescue HTTP::Error => e
+        raise UnknownHTTPError, 'Unhandled HTTP error encountered'
+      # If configured, the client will wait whenever the `RateLimitExceeded` exception
+      # is raised. Check `Fulfil::Configuration` for more details.
+      rescue RateLimitExceeded => e
+        raise e unless config.retry_on_rate_limit?
 
-      attempts += 1
-      raise e if attempts > config.retry_on_rate_limit_max_attempts
+        attempts += 1
+        raise e if attempts > config.retry_on_rate_limit_max_attempts
 
-      sleep(rate_limit_retry_wait)
-      retry
+        sleep(rate_limit_retry_wait)
+        retry
+      end
     end
 
     def rate_limit_retry_wait

--- a/lib/fulfil/client.rb
+++ b/lib/fulfil/client.rb
@@ -157,6 +157,8 @@ module Fulfil
     end
 
     def request(endpoint:, verb: :get, **args)
+      attempts = 0
+
       response = client.request(verb, endpoint, args)
       Fulfil::ResponseHandler.new(response).verify!
 
@@ -172,8 +174,35 @@ module Fulfil
     rescue RateLimitExceeded => e
       raise e unless config.retry_on_rate_limit?
 
-      sleep config.retry_on_rate_limit_wait
+      attempts += 1
+      raise e if attempts > config.retry_on_rate_limit_max_attempts
+
+      sleep(rate_limit_retry_wait)
       retry
+    end
+
+    def rate_limit_retry_wait
+      wait = reset_aware_retry_wait || config.retry_on_rate_limit_wait.to_f
+      apply_jitter(wait)
+    end
+
+    def reset_aware_retry_wait
+      return unless config.retry_on_rate_limit_use_reset_at
+
+      reset_at = Fulfil.rate_limit.resets_at
+      return unless reset_at
+
+      reset_time = reset_at.respond_to?(:to_time) ? reset_at.to_time : Time.at(reset_at.to_i).utc
+      [reset_time - Time.now.utc, 0].max
+    end
+
+    def apply_jitter(wait)
+      jitter_ratio = config.retry_on_rate_limit_jitter.to_f
+      return wait if jitter_ratio <= 0
+
+      min = wait * (1 - jitter_ratio)
+      max = wait * (1 + jitter_ratio)
+      rand(min..max)
     end
 
     def client

--- a/lib/fulfil/client.rb
+++ b/lib/fulfil/client.rb
@@ -129,9 +129,19 @@ module Fulfil
     end
 
     def parse(result: nil, results: [])
-      return Fulfil::ResponseParser.parse(item: result) if result
+      if result
+        parse_single(result: result)
+      else
+        parse_multiple(results: results)
+      end
+    end
 
-      results.map { |item| Fulfil::ResponseParser.parse(item: item) }
+    def parse_single(result:)
+      Fulfil::ResponseParser.parse(item: result)
+    end
+
+    def parse_multiple(results:)
+      results.map { |result| Fulfil::ResponseParser.parse(item: result) }
     end
 
     def domain

--- a/lib/fulfil/configuration.rb
+++ b/lib/fulfil/configuration.rb
@@ -9,10 +9,8 @@ module Fulfil
     # Allow the `Fulfil::Client` to automatically retry when the rate limit is hit.
     # By default, the `Fulfil::Client` will wait 1 second before retrying again.
     attr_accessor :retry_on_rate_limit
-    attr_accessor :retry_on_rate_limit_wait
-    attr_accessor :retry_on_rate_limit_max_attempts
-    attr_accessor :retry_on_rate_limit_jitter
-    attr_accessor :retry_on_rate_limit_use_reset_at
+    attr_accessor :retry_on_rate_limit_wait, :retry_on_rate_limit_max_attempts, :retry_on_rate_limit_jitter,
+                  :retry_on_rate_limit_use_reset_at
 
     # Allows the client to configure a notification handler. Can be used by APM
     # tools to monitor the number of rate limit hits.

--- a/lib/fulfil/configuration.rb
+++ b/lib/fulfil/configuration.rb
@@ -10,6 +10,9 @@ module Fulfil
     # By default, the `Fulfil::Client` will wait 1 second before retrying again.
     attr_accessor :retry_on_rate_limit
     attr_accessor :retry_on_rate_limit_wait
+    attr_accessor :retry_on_rate_limit_max_attempts
+    attr_accessor :retry_on_rate_limit_jitter
+    attr_accessor :retry_on_rate_limit_use_reset_at
 
     # Allows the client to configure a notification handler. Can be used by APM
     # tools to monitor the number of rate limit hits.
@@ -38,6 +41,9 @@ module Fulfil
     def initialize
       @retry_on_rate_limit = false
       @retry_on_rate_limit_wait = 1
+      @retry_on_rate_limit_max_attempts = 3
+      @retry_on_rate_limit_jitter = 0.2
+      @retry_on_rate_limit_use_reset_at = true
       @logger = Logger.new($stderr)
     end
 

--- a/lib/fulfil/rate_limit_retry_wait.rb
+++ b/lib/fulfil/rate_limit_retry_wait.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Fulfil
+  # Calculates retry wait duration using reset-aware timing and jitter fallback.
+  class RateLimitRetryWait
+    def self.call(config:, reset_at:, now: Time.now.utc)
+      wait = reset_aware_wait(config: config, reset_at: reset_at, now: now) || config.retry_on_rate_limit_wait.to_f
+      apply_jitter(wait, config.retry_on_rate_limit_jitter)
+    end
+
+    def self.reset_aware_wait(config:, reset_at:, now:)
+      return unless config.retry_on_rate_limit_use_reset_at
+      return unless reset_at
+
+      reset_time = reset_at.respond_to?(:to_time) ? reset_at.to_time : Time.at(reset_at.to_i).utc
+      [reset_time - now, 0].max
+    end
+
+    def self.apply_jitter(wait, jitter_ratio)
+      jitter_ratio = jitter_ratio.to_f
+      return wait if jitter_ratio <= 0
+
+      min = wait * (1 - jitter_ratio)
+      max = wait * (1 + jitter_ratio)
+      rand(min..max)
+    end
+  end
+end

--- a/test/fulfil/client_test.rb
+++ b/test/fulfil/client_test.rb
@@ -3,6 +3,7 @@
 require 'test_helper'
 
 module Fulfil
+  # rubocop:disable Metrics/ClassLength
   class ClientTest < Minitest::Test
     def test_invalid_client
       assert_raises('InvalidClientError') { Fulfil::Client.new(subdomain: nil, token: nil) }
@@ -105,11 +106,11 @@ module Fulfil
     def test_retry_has_max_attempts
       sale_id = 404
       request_stub = stub_request(:get, fulfil_url_for("sale.sale/#{sale_id}"))
-        .to_return(status: 200, body: '', headers: {
-                     'Content-Type': 'application/json',
-                     'X-RateLimit-Remaining': 0,
-                     'X-RateLimit-Reset' => (Time.now.utc.to_i + 1).to_s
-                   })
+                     .to_return(status: 200, body: '', headers: {
+                                  'Content-Type': 'application/json',
+                                  'X-RateLimit-Remaining': 0,
+                                  'X-RateLimit-Reset' => (Time.now.utc.to_i + 1).to_s
+                                })
 
       with_fulfil_config do |config|
         config.retry_on_rate_limit = true
@@ -128,7 +129,6 @@ module Fulfil
 
     def test_retry_prefers_rate_limit_reset_header
       fixed_now = Time.utc(2026, 3, 4, 0, 0, 0)
-
       with_fulfil_config do |config|
         config.retry_on_rate_limit_wait = 0.01
         config.retry_on_rate_limit_jitter = 0
@@ -138,7 +138,7 @@ module Fulfil
         Fulfil.rate_limit.resets_at = Time.at(fixed_now.to_i + 3).utc.to_datetime
 
         Time.stub(:now, fixed_now) do
-          assert_equal 3.0, client.send(:rate_limit_retry_wait)
+          assert_in_delta(3.0, client.send(:rate_limit_retry_wait))
         end
       end
     end
@@ -148,11 +148,10 @@ module Fulfil
         config.retry_on_rate_limit_wait = 1
         config.retry_on_rate_limit_use_reset_at = false
         config.retry_on_rate_limit_jitter = 0.25
-
         client = Fulfil::Client.new
 
-        client.stub(:rand, 1.1) do
-          assert_equal 1.1, client.send(:rate_limit_retry_wait)
+        Fulfil::RateLimitRetryWait.stub(:rand, 1.1) do
+          assert_in_delta(1.1, client.send(:rate_limit_retry_wait))
         end
       end
     end
@@ -181,4 +180,5 @@ module Fulfil
       end
     end
   end
+  # rubocop:enable Metrics/ClassLength
 end

--- a/test/fulfil/client_test.rb
+++ b/test/fulfil/client_test.rb
@@ -102,6 +102,61 @@ module Fulfil
       end
     end
 
+    def test_retry_has_max_attempts
+      sale_id = 404
+      request_stub = stub_request(:get, fulfil_url_for("sale.sale/#{sale_id}"))
+        .to_return(status: 200, body: '', headers: {
+                     'Content-Type': 'application/json',
+                     'X-RateLimit-Remaining': 0,
+                     'X-RateLimit-Reset' => (Time.now.utc.to_i + 1).to_s
+                   })
+
+      with_fulfil_config do |config|
+        config.retry_on_rate_limit = true
+        config.retry_on_rate_limit_wait = 0
+        config.retry_on_rate_limit_max_attempts = 2
+        config.retry_on_rate_limit_use_reset_at = false
+        config.retry_on_rate_limit_jitter = 0
+
+        assert_raises Fulfil::RateLimitExceeded do
+          Fulfil::Client.new.find_one(model: 'sale.sale', id: sale_id)
+        end
+      end
+
+      assert_requested request_stub, times: 3
+    end
+
+    def test_retry_prefers_rate_limit_reset_header
+      fixed_now = Time.utc(2026, 3, 4, 0, 0, 0)
+
+      with_fulfil_config do |config|
+        config.retry_on_rate_limit_wait = 0.01
+        config.retry_on_rate_limit_jitter = 0
+        config.retry_on_rate_limit_use_reset_at = true
+
+        client = Fulfil::Client.new
+        Fulfil.rate_limit.resets_at = Time.at(fixed_now.to_i + 3).utc.to_datetime
+
+        Time.stub(:now, fixed_now) do
+          assert_equal 3.0, client.send(:rate_limit_retry_wait)
+        end
+      end
+    end
+
+    def test_retry_applies_jitter
+      with_fulfil_config do |config|
+        config.retry_on_rate_limit_wait = 1
+        config.retry_on_rate_limit_use_reset_at = false
+        config.retry_on_rate_limit_jitter = 0.25
+
+        client = Fulfil::Client.new
+
+        client.stub(:rand, 1.1) do
+          assert_equal 1.1, client.send(:rate_limit_retry_wait)
+        end
+      end
+    end
+
     def test_connection_error_maps_to_connection_error
       client = Fulfil::Client.new(subdomain: 'test', token: '123')
       transport = Object.new

--- a/test/fulfil/configuration_test.rb
+++ b/test/fulfil/configuration_test.rb
@@ -14,6 +14,12 @@ module Fulfil
       end
     end
 
+    def test_rate_limit_retry_defaults
+      assert_equal 3, Fulfil.config.retry_on_rate_limit_max_attempts
+      assert_equal 0.2, Fulfil.config.retry_on_rate_limit_jitter
+      assert_equal true, Fulfil.config.retry_on_rate_limit_use_reset_at
+    end
+
     def test_default_logger
       assert_instance_of Logger, Fulfil.config.logger
     end

--- a/test/fulfil/configuration_test.rb
+++ b/test/fulfil/configuration_test.rb
@@ -16,8 +16,8 @@ module Fulfil
 
     def test_rate_limit_retry_defaults
       assert_equal 3, Fulfil.config.retry_on_rate_limit_max_attempts
-      assert_equal 0.2, Fulfil.config.retry_on_rate_limit_jitter
-      assert_equal true, Fulfil.config.retry_on_rate_limit_use_reset_at
+      assert_in_delta(0.2, Fulfil.config.retry_on_rate_limit_jitter)
+      assert Fulfil.config.retry_on_rate_limit_use_reset_at
     end
 
     def test_default_logger


### PR DESCRIPTION
## Summary

This PR improves `RateLimitExceeded` retry behavior in `Fulfil::Client` by adding:

- jittered retry waits
- maximum retry attempts
- reset-aware waiting using `X-RateLimit-Reset` when available

## Changes

- Added new configuration options:
  - `retry_on_rate_limit_max_attempts` (default: `3`)
  - `retry_on_rate_limit_jitter` (default: `0.2`)
  - `retry_on_rate_limit_use_reset_at` (default: `true`)
- Updated retry flow in `Client#request`:
  - caps retries by max attempts
  - prefers reset-aware wait (`X-RateLimit-Reset`)
  - applies jitter to reduce synchronized retries
- Added tests for:
  - max retry cap
  - reset-aware wait preference
  - jitter application
- Updated README retry configuration docs

Closes #33
Closes #34
