### PR TITLE
Add support for context URL option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Add robust query/domain parsing and value conversion for Fulfil-style filters, including date and datetime coercion, HTML entity normalization, and operator mapping.
 * Improve client query handling and test coverage for converted search domains and date/datetime filtering behavior.
 * Documentation updates for query conversion and domain parsing behavior.
+* Add support for Fulfil `context` URL option on `search` and `count` calls.
 
 ## 0.9.0
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,14 @@ sales = sale_model.search(
   fields: ['id', 'rec_name', 'lines']
 )
 
+# Optional: pass context as a URL option (Fulfil expects a JSON string)
+# Useful for location-specific inventory calls.
+inventory = Fulfil::Model.new(client: fulfil, model_name: 'product.product').search(
+  domain: [['id', 'in', [1, 2, 3]]],
+  fields: ['id', 'rec_name', 'quantity_available'],
+  context: { locations: [10, 11] }
+)
+
 # -- OR --
 
 sale_model.query(id: 100)

--- a/lib/fulfil/client.rb
+++ b/lib/fulfil/client.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'http'
+require 'json'
 require 'logger'
 require 'fulfil/response_parser'
 require 'fulfil/domain_parser'
@@ -75,17 +76,24 @@ module Fulfil
       parse(results: results)
     end
 
-    def search(model:, domain:, offset: nil, limit: 100, sort: nil, fields: %w[id])
-      uri = URI("#{model_url(model: model)}/search_read")
+    def search(model:, domain:, **options)
+      context = options.fetch(:context, nil)
+      uri = model_uri(model: model, endpoint: 'search_read', context: context)
       parsed_domain = Fulfil::DomainParser.new(domain).parsed
-      body = [parsed_domain, offset, limit, sort, fields]
+      body = [
+        parsed_domain,
+        options.fetch(:offset, nil),
+        options.fetch(:limit, 100),
+        options.fetch(:sort, nil),
+        options.fetch(:fields, %w[id])
+      ]
 
       results = request(verb: :put, endpoint: uri, json: body)
       parse(results: results)
     end
 
-    def count(model:, domain:)
-      uri = URI("#{model_url(model: model)}/search_count")
+    def count(model:, domain:, context: nil)
+      uri = model_uri(model: model, endpoint: 'search_count', context: context)
       parsed_domain = Fulfil::DomainParser.new(domain).parsed
       body = [parsed_domain]
 
@@ -157,6 +165,18 @@ module Fulfil
 
     def model_url(model:, id: nil, endpoint: nil)
       [base_url, 'model', model, id, endpoint].compact.join('/')
+    end
+
+    def model_uri(model:, id: nil, endpoint: nil, context: nil)
+      uri = URI(model_url(model: model, id: id, endpoint: endpoint))
+      return uri if context.nil?
+
+      uri.query = URI.encode_www_form(context: context_query_value(context))
+      uri
+    end
+
+    def context_query_value(context)
+      context.is_a?(String) ? context : context.to_json
     end
 
     def request(endpoint:, verb: :get, **args)

--- a/lib/fulfil/model.rb
+++ b/lib/fulfil/model.rb
@@ -20,14 +20,35 @@ module Fulfil
 
     # Delegate this to the client, including the model_name so we don't have to
     # type it every time.
-    def search(domain:, model: model_name, fields: %w[id rec_name], **options)
+    #
+    # @param domain [Array] Fulfil domain query
+    # @param model [String] Fulfil model name
+    # @param fields [Array<String>] fields to return
+    # @param limit [Integer, nil] max number of records
+    # @param offset [Integer, nil] record offset
+    # @param sort [String, nil] sort expression, e.g. "id DESC"
+    # @param context [Hash, String, nil] optional Fulfil context URL param
+    # rubocop:disable Metrics/ParameterLists
+    def search(
+      domain:,
+      model: model_name,
+      fields: %w[id rec_name],
+      limit: nil,
+      offset: nil,
+      sort: nil,
+      context: nil
+    )
       @client.search(
         model: model,
         domain: domain,
         fields: fields,
-        **options
+        limit: limit,
+        offset: offset,
+        sort: sort,
+        context: context
       )
     end
+    # rubocop:enable Metrics/ParameterLists
 
     def count(domain:, context: nil)
       @client.count(model: model_name, domain: domain, context: context)

--- a/lib/fulfil/model.rb
+++ b/lib/fulfil/model.rb
@@ -20,26 +20,17 @@ module Fulfil
 
     # Delegate this to the client, including the model_name so we don't have to
     # type it every time.
-    def search(
-      domain:,
-      model: model_name,
-      fields: %w[id rec_name],
-      limit: nil,
-      offset: nil,
-      sort: nil
-    )
+    def search(domain:, model: model_name, fields: %w[id rec_name], **options)
       @client.search(
         model: model,
         domain: domain,
         fields: fields,
-        limit: limit,
-        offset: offset,
-        sort: sort
+        **options
       )
     end
 
-    def count(domain:)
-      @client.count(model: model_name, domain: domain)
+    def count(domain:, context: nil)
+      @client.count(model: model_name, domain: domain, context: context)
     end
 
     def all

--- a/test/fulfil/client_test.rb
+++ b/test/fulfil/client_test.rb
@@ -72,6 +72,34 @@ module Fulfil
       assert_equal 362_560, order_count
     end
 
+    def test_search_supports_context_url_option
+      context = { locations: [12, 34] }
+      expected_context = context.to_json
+
+      request_stub = stub_request(:put, fulfil_url_for('product.product/search_read'))
+                     .with(query: { context: expected_context })
+                     .to_return(status: 200, body: [].to_json, headers: valid_response_headers)
+
+      client = Fulfil::Client.new
+      client.search(model: 'product.product', domain: [], context: context)
+
+      assert_requested request_stub, times: 1
+    end
+
+    def test_count_supports_context_url_option
+      context = { locations: [12, 34] }
+      expected_context = context.to_json
+
+      request_stub = stub_request(:put, fulfil_url_for('product.product/search_count'))
+                     .with(query: { context: expected_context })
+                     .to_return(status: 200, body: '0', headers: valid_response_headers)
+
+      client = Fulfil::Client.new
+      client.count(model: 'product.product', domain: [], context: context)
+
+      assert_requested request_stub, times: 1
+    end
+
     def test_retry_on_request_failure_when_configured
       sale_id = 404
 

--- a/test/fulfil/model_test.rb
+++ b/test/fulfil/model_test.rb
@@ -14,5 +14,38 @@ module Fulfil
       assert_equal [['id', 'in', [1, 2, 3]]], sales.query
       assert_empty sales.all
     end
+
+    def test_search_forwards_only_whitelisted_options
+      context = { locations: [10] }
+      base_url = fulfil_url_for('sale.sale/search_read')
+
+      stub_request(:put, /#{Regexp.escape(base_url)}(\?.*)?/)
+        .to_return(status: 200, body: [].to_json, headers: { 'Content-Type': 'application/json' })
+
+      sales = Fulfil::Model.new(client: Fulfil::Client.new, model_name: 'sale.sale')
+      sales.search(
+        domain: [],
+        fields: %w[id],
+        limit: 25,
+        offset: 10,
+        sort: 'id DESC',
+        context: { locations: [10] }
+      )
+
+      assert_requested(:put, /#{Regexp.escape(base_url)}(\?.*)?/, times: 1) do |request|
+        query = URI.decode_www_form(URI(request.uri).query || '').to_h
+
+        assert_equal context.to_json, query['context']
+        assert_equal [[], 10, 25, 'id DESC', ['id']], JSON.parse(request.body)
+      end
+    end
+
+    def test_search_rejects_unknown_keywords
+      sales = Fulfil::Model.new(client: Fulfil::Client.new, model_name: 'sale.sale')
+
+      assert_raises(ArgumentError) do
+        sales.search(domain: [], foo: 'bar')
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary
- add `context:` support to `Fulfil::Client#search` and `Fulfil::Client#count`
- serialize hash context values to JSON and append them as URL query params
- pass `context:` through `Fulfil::Model#search` and `Fulfil::Model#count`
- add client tests for context query support
- document the option in README and changelog

Closes #63

## Testing
- `bundle exec ruby -Itest test/fulfil/client_test.rb test/fulfil/model_test.rb`
- `bundle exec rubocop lib/fulfil/client.rb lib/fulfil/model.rb test/fulfil/client_test.rb`
